### PR TITLE
Aragon Communication Tools + Datastore Encryption Support Request

### DIFF
--- a/grants/Communication Tools/README.md
+++ b/grants/Communication Tools/README.md
@@ -10,7 +10,7 @@
 
 [Team](https://docs.google.com/document/d/1d-pt5Uj52TiPm7alZUJmZ4RP48IQLeHfyH_OgHci7ms/edit#bookmark=id.2o3istifvmr) and [Roadmap](https://docs.google.com/document/d/1d-pt5Uj52TiPm7alZUJmZ4RP48IQLeHfyH_OgHci7ms/edit#bookmark=id.78mdhat2qwo)
 
-## Proposal: Datastore + Aragon Drive App
+## Proposal: Aragon Communication Tools + Datastore Encryption Support
 
 We believe that building tools that facilitate communication is an integral part of our work on DAOs. That is why alongside the launch of [Espresso Drive](https://github.com/espresso-org/aragon-drive), we have also released the [aragon-comments](https://github.com/espresso-org/aragon-comments) widget, which offers an easy way for developers to integrate comment threads in their Aragon App.
 

--- a/grants/Communication Tools/README.md
+++ b/grants/Communication Tools/README.md
@@ -1,0 +1,29 @@
+# Request for Nest membership and funding (#49)
+
+**Team name**: Espresso Team
+
+**Research whitepaper**: [Whitepaper](https://docs.google.com/document/d/1d-pt5Uj52TiPm7alZUJmZ4RP48IQLeHfyH_OgHci7ms/edit?usp=sharing)
+
+**Burn rate**: $18k/month for 6 months
+
+**Legal structure**: TBD
+
+[Team](https://docs.google.com/document/d/1d-pt5Uj52TiPm7alZUJmZ4RP48IQLeHfyH_OgHci7ms/edit#bookmark=id.2o3istifvmr) and [Roadmap](https://docs.google.com/document/d/1d-pt5Uj52TiPm7alZUJmZ4RP48IQLeHfyH_OgHci7ms/edit#bookmark=id.78mdhat2qwo)
+
+## Proposal: Datastore + Aragon Drive App
+
+We believe that building tools that facilitate communication is an integral part of our work on DAOs. That is why alongside the launch of [Espresso Drive](https://github.com/espresso-org/aragon-drive), we have also released the [aragon-comments](https://github.com/espresso-org/aragon-comments) widget, which offers an easy way for developers to integrate comment threads in their Aragon App.
+
+While aragon-comments currently stores messages on-chain, we have discussed with developers from Status and established a roadmap on how to migrate to Whisper and possibly to their [Network Incentivisation Protocol](https://discuss.status.im/t/network-incentivisation-first-draft/1037) when it becomes available.
+
+Besides reducing the friction of participating in a discussion, storing messages off-chain would enable many features that were previously difficult to implement, including the ones found in the [Nest Proposal #49: better communication tools for effective governance](https://github.com/aragon/nest/issues/48).
+
+Also, the current release of Espresso Drive doesn’t support encryption as no privacy layer was available during the development schedule of our Aragon Nest contract. Fortunately, we recently found a solution to this problem using deterministic key pair generation.
+
+We therefore submit in the following document a 6 months funding request during which we propose to:
+
+1. Build and release a complete implementation of the Discussion App, specified in the Nest #49 proposal. A proof of concept is available [here](https://github.com/espresso-org/communication-poc) along with a [demo](https://www.youtube.com/watch?v=94HOq2YrNl0).
+2. Improve the aragon-comments widget and migrate it to an off-chain protocol.
+3. Implement file encryption support to the Datastore and Espresso Drive, along with other improvements such as extracting the “Groups” section into a standalone app.
+
+Finally, and most importantly for us, this funding would let us continue working within the Aragon community, helping out new users and other Nest teams get up and running with their projects, contributing to Aragon codebase and to continue to take part in the decentralization movement full time.

--- a/grants/Communication Tools/README.md
+++ b/grants/Communication Tools/README.md
@@ -16,7 +16,7 @@ We believe that building tools that facilitate communication is an integral part
 
 While aragon-comments currently stores messages on-chain, we have discussed with developers from Status and established a roadmap on how to migrate to Whisper and possibly to their [Network Incentivisation Protocol](https://discuss.status.im/t/network-incentivisation-first-draft/1037) when it becomes available.
 
-Besides reducing the friction of participating in a discussion, storing messages off-chain would enable many features that were previously difficult to implement, including the ones found in the [Nest Proposal #49: better communication tools for effective governance](https://github.com/aragon/nest/issues/48).
+Besides reducing the friction of participating in a discussion, storing messages off-chain would enable many features that were previously difficult to implement, including the ones found in the [Nest Proposal #49: better communication tools for effective governance](https://github.com/aragon/nest/issues/49).
 
 Also, the current release of Espresso Drive doesn’t support encryption as no privacy layer was available during the development schedule of our Aragon Nest contract. Fortunately, we recently found a solution to this problem using deterministic key pair generation.
 

--- a/grants/Communication Tools/README.md
+++ b/grants/Communication Tools/README.md
@@ -22,7 +22,7 @@ Also, the current release of Espresso Drive doesn’t support encryption as no p
 
 We therefore submit in the following document a 6 months funding request during which we propose to:
 
-1. Build and release a complete implementation of the Discussion App, specified in the Nest #49 proposal. A proof of concept is available [here](https://github.com/espresso-org/communication-poc) along with a [demo](https://www.youtube.com/watch?v=94HOq2YrNl0).
+1. Build and release a complete implementation of the Discussion App, specified in the [Nest #49 proposal](https://github.com/aragon/nest/issues/49). A proof of concept is available [here](https://github.com/espresso-org/communication-poc) along with a [demo](https://www.youtube.com/watch?v=94HOq2YrNl0).
 2. Improve the aragon-comments widget and migrate it to an off-chain protocol.
 3. Implement file encryption support to the Datastore and Espresso Drive, along with other improvements such as extracting the “Groups” section into a standalone app.
 

--- a/grants/Communication Tools/burnrate.md
+++ b/grants/Communication Tools/burnrate.md
@@ -1,0 +1,3 @@
+# Burn rate
+
+$18k/month for 6 months

--- a/grants/Communication Tools/proposal.md
+++ b/grants/Communication Tools/proposal.md
@@ -1,0 +1,18 @@
+# Aragon Communication Tools + Datastore Encryption Support
+
+We believe that building tools that facilitate communication is an integral part of our work on DAOs. That is why alongside the launch of [Espresso Drive](https://github.com/espresso-org/aragon-drive), we have also released the [aragon-comments](https://github.com/espresso-org/aragon-comments) widget, which offers an easy way for developers to integrate comment threads in their Aragon App.
+
+While aragon-comments currently stores messages on-chain, we have discussed with developers from Status and established a roadmap on how to migrate to Whisper and possibly to their [Network Incentivisation Protocol](https://discuss.status.im/t/network-incentivisation-first-draft/1037) when it becomes available.
+
+Besides reducing the friction of participating in a discussion, storing messages off-chain would enable many features that were previously difficult to implement, including the ones found in the Nest Proposal #49: better communication tools for effective governance.
+
+Also, the current release of Espresso Drive doesn’t support encryption as no privacy layer was available during the development schedule of our Aragon Nest contract. Fortunately, we recently found a solution to this problem using deterministic key pair generation.
+
+We therefore submit in the following document a 6 months funding request during which we propose to:
+
+1. Build and release a complete implementation of the Discussion App, specified in the Nest #49 proposal. A proof of concept is available [here](https://github.com/espresso-org/communication-poc) along with a [demo](https://www.youtube.com/watch?v=94HOq2YrNl0).
+2. Improve the aragon-comments widget and migrate it to an off-chain protocol.
+3. Implement file encryption support to the Datastore and Espresso Drive, along with other improvements such as extracting the “Groups” section into a standalone app.
+
+Finally, and most importantly for us, this funding would let us continue working within the Aragon community, helping out new users and other Nest teams get up and running with their projects, contributing to Aragon codebase and to continue to take part in the decentralization movement full time.
+

--- a/grants/Communication Tools/proposal.md
+++ b/grants/Communication Tools/proposal.md
@@ -10,7 +10,7 @@ Also, the current release of Espresso Drive doesn’t support encryption as no p
 
 We therefore submit in the following document a 6 months funding request during which we propose to:
 
-1. Build and release a complete implementation of the Discussion App, specified in the Nest #49 proposal. A proof of concept is available [here](https://github.com/espresso-org/communication-poc) along with a [demo](https://www.youtube.com/watch?v=94HOq2YrNl0).
+1. Build and release a complete implementation of the Discussion App, specified in the [Nest #49 proposal](https://github.com/aragon/nest/issues/49). A proof of concept is available [here](https://github.com/espresso-org/communication-poc) along with a [demo](https://www.youtube.com/watch?v=94HOq2YrNl0).
 2. Improve the aragon-comments widget and migrate it to an off-chain protocol.
 3. Implement file encryption support to the Datastore and Espresso Drive, along with other improvements such as extracting the “Groups” section into a standalone app.
 

--- a/grants/Communication Tools/roadmap.md
+++ b/grants/Communication Tools/roadmap.md
@@ -1,28 +1,36 @@
 # Roadmap
 
-### Preliminary Datastore build - 12 weeks
-1. Basic smart contracts
-2. AragonOS integration
-3. Permissions support
-4. Set up IPFS servers
-5. Implement IPFS storage
+### 1. Datastore/Drive Encryption Support - 6 weeks
 
-### Encryption integration - 12 weeks
-1. Keep integration
-2. Add encryption and hash algorithms
-3. Complete Datastore javascript interface
-4. Rigorous testing
+- Datastore FILE_READ permission
+- Espresso Drive’s updated interface
+- Group app
+- Implement a sign intent into aragon.js
 
-### Aragon Drive MVP - 8 weeks
-1. Finalize UX design
-2. Implement the folder structures
-3. Implement the sharing features
-4. Testing the Datastore with a real app
-5. Complete the Datastore documentation
-6. Testnet release of the Drive app
+### 2. Message Layer Implementation - 4 weeks
 
-### Aragon Drive Release - 4 weeks
-1. Comments support
-2. Labels support
-3. Testing of the app
-4. Mainnet release
+- Complete message structure
+- Signing
+- Author validation
+- Discussion filters
+- Whisper geth node configuration and doc
+
+### 3. Participation Logic and Mail Servers - 6 weeks
+
+- Smart contract participation logic
+- Forwarding support
+- Time-locked discussions
+- Mail server implementation
+
+### 4. Blacklist and Moderators - 4 weeks
+
+- Blacklist support
+- Delete message support
+- aragon-comments widget upgrade
+- Complete UI
+
+### 5. Release - 4 weeks
+
+- IPFS mail server
+- 100% smart contract test coverage
+- Final release

--- a/grants/Communication Tools/roadmap.md
+++ b/grants/Communication Tools/roadmap.md
@@ -1,0 +1,28 @@
+# Roadmap
+
+### Preliminary Datastore build - 12 weeks
+1. Basic smart contracts
+2. AragonOS integration
+3. Permissions support
+4. Set up IPFS servers
+5. Implement IPFS storage
+
+### Encryption integration - 12 weeks
+1. Keep integration
+2. Add encryption and hash algorithms
+3. Complete Datastore javascript interface
+4. Rigorous testing
+
+### Aragon Drive MVP - 8 weeks
+1. Finalize UX design
+2. Implement the folder structures
+3. Implement the sharing features
+4. Testing the Datastore with a real app
+5. Complete the Datastore documentation
+6. Testnet release of the Drive app
+
+### Aragon Drive Release - 4 weeks
+1. Comments support
+2. Labels support
+3. Testing of the app
+4. Mainnet release

--- a/grants/Communication Tools/team.md
+++ b/grants/Communication Tools/team.md
@@ -1,0 +1,34 @@
+# Team
+
+## Mathew Cormier - Project Lead
+
+Mathew is a software engineer from Quebec City, Canada. He is currently project lead at Espresso and a regular contributor on many open source projects. Before joining the Aragon Nest umbrella, Mathew has worked for almost a decade on the development of workflow management systems.
+
+Commitment: Full time <br />
+Socials:  [GitHub](https://www.github.com/macor161)
+
+
+## Justin Laroche - Software Engineer
+
+Justin is a skilled software engineer with a few years of experience working on different web projects. Since August 2018, he has been developing dApps full time as part of the Aragon Nest program. He is a fervent enthusiast of decentralized projects.
+
+Commitment: Full Time <br />
+Socials:  [GitHub](https://github.com/juslar)
+
+
+## Maxime Cote - Solidity Developer
+
+Maxime has been an unconditional advocate of cryptocurrencies and decentralization in general since 2011. Graduate from Ottawa University, he obtained his bachelor's degree in Mathematics 5 years ago. He is a self-taught programmer with good skills in C++ and Javascript and has been working on smart contracts full-time for almost a year.
+
+Commitment: Full Time <br />
+Socials:  [GitHub](https://github.com/leftab)
+
+
+
+## Marie-Ève Blanchette - Graphic Designer 
+
+Marie-Ève is a talented visual artist and designer from Quebec City, Canada. She obtained her baccalaureate of Arts and Animation Science from Laval University 2 years ago. She has a growing interest in web design and developing an online visual identity.
+
+Commitment: Part Time
+
+


### PR DESCRIPTION
# Request for Nest membership and funding (#49)

**Team name**: Espresso Team

**Research whitepaper**: [Whitepaper](https://docs.google.com/document/d/1d-pt5Uj52TiPm7alZUJmZ4RP48IQLeHfyH_OgHci7ms/edit?usp=sharing)

**Burn rate**: $18k/month for 6 months

**Legal structure**: TBD

[Team](https://docs.google.com/document/d/1d-pt5Uj52TiPm7alZUJmZ4RP48IQLeHfyH_OgHci7ms/edit#bookmark=id.2o3istifvmr) and [Roadmap](https://docs.google.com/document/d/1d-pt5Uj52TiPm7alZUJmZ4RP48IQLeHfyH_OgHci7ms/edit#bookmark=id.78mdhat2qwo)

## Proposal: Aragon Communication Tools + Datastore Encryption Support

We believe that building tools that facilitate communication is an integral part of our work on DAOs. That is why alongside the launch of [Espresso Drive](https://github.com/espresso-org/aragon-drive), we have also released the [aragon-comments](https://github.com/espresso-org/aragon-comments) widget, which offers an easy way for developers to integrate comment threads in their Aragon App.

While aragon-comments currently stores messages on-chain, we have discussed with developers from Status and established a roadmap on how to migrate to Whisper and possibly to their [Network Incentivisation Protocol](https://discuss.status.im/t/network-incentivisation-first-draft/1037) when it becomes available.

Besides reducing the friction of participating in a discussion, storing messages off-chain would enable many features that were previously difficult to implement, including the ones found in the [Nest Proposal #49: better communication tools for effective governance](https://github.com/aragon/nest/issues/49).

Also, the current release of Espresso Drive doesn’t support encryption as no privacy layer was available during the development schedule of our Aragon Nest contract. Fortunately, we recently found a solution to this problem using deterministic key pair generation.

We therefore submit in the following document a 6 months funding request during which we propose to:

1. Build and release a complete implementation of the Discussion App, specified in the [Nest #49 proposal](https://github.com/aragon/nest/issues/49). A proof of concept is available [here](https://github.com/espresso-org/communication-poc) along with a [demo](https://www.youtube.com/watch?v=94HOq2YrNl0).
2. Improve the aragon-comments widget and migrate it to an off-chain protocol.
3. Implement file encryption support to the Datastore and Espresso Drive, along with other improvements such as extracting the “Groups” section into a standalone app.

Finally, and most importantly for us, this funding would let us continue working within the Aragon community, helping out new users and other Nest teams get up and running with their projects, contributing to Aragon codebase and to continue to take part in the decentralization movement full time.